### PR TITLE
Refactor 'Raise ActiveRecord::ConnectionNotEstablished on calls to execute with a disconnected connection'

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -374,7 +374,7 @@ module ActiveRecord
       end
 
       def translate_exception(e, message:, sql:, binds:)
-        return ActiveRecord::ConnectionNotEstablished.new("SQLServer client is not connected") if e.is_a?(ActiveRecord::ConnectionNotEstablished)
+        return e if e.is_a?(ActiveRecord::ConnectionNotEstablished)
 
         case message
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i

--- a/test/cases/disconnected_test_sqlserver.rb
+++ b/test/cases/disconnected_test_sqlserver.rb
@@ -18,7 +18,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
   test "can't execute procuderes while disconnected" do
     @connection.execute_procedure :sp_tables, "sst_datatypes"
     @connection.disconnect!
-    assert_raises(ActiveRecord::ConnectionNotEstablished) do
+    assert_raises(ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected') do
       @connection.execute_procedure :sp_tables, "sst_datatypes"
     end
   end
@@ -32,7 +32,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
 
     @connection.exec_query sql, "TEST", binds
     @connection.disconnect!
-    assert_raises(ActiveRecord::ConnectionNotEstablished) do
+    assert_raises(ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected') do
       @connection.exec_query sql, "TEST", binds
     end
   end


### PR DESCRIPTION
@mgrunberg Thought https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903 looked good but could be refactored a little. Easier to make my suggestions this way rather than through comments. 


