### PR TITLE
Changed handling of dead connections

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -464,7 +464,7 @@ module ActiveRecord
         end
 
         def ensure_established_connection!
-          raise TinyTds::Error, 'SQL Server client is not connected' if @connection.nil? || !@connection.active?
+          raise TinyTds::Error, 'SQL Server client is not connected' unless @connection
 
           yield
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -375,7 +375,7 @@ module ActiveRecord
 
       def translate_exception(e, message:, sql:, binds:)
         case message
-        when /SQL Server client is not connected/
+        when /(SQL Server client is not connected) | (failed to execute statement)/i
           ConnectionNotEstablished.new(message)
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds)


### PR DESCRIPTION
Suggested changes related to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903: 

1. Do not check if a connection is dead/alive before using it. Using `connection.active?` would mean an extra call to the database for every query. We will know whether the connection is dead based on whether TinyTds::Error("failed to execute statement") is thrown. Removed `!@connection.active?` from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903/files#diff-f749b206a3bbfaa7e02aa77f1c26715bea21134aa6d2645cbf9068783e280cf8R467

2. If a connection is disconnected or dead then a `ConnectionNotEstablished` should be thrown. The disconnection part is already done. We just need to check if the connection was dead. This can be detected by checking for the "failed to execute statement" error message when translating the exception (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903/files#diff-3562da8bff63a7b06dce2a8b9e1163ab5598cca3bcaaf1b971a1c3e40942b053R378).
